### PR TITLE
feat: return sync iterables when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ function concat(...iterables: Array<Iterable<any>>): IterableIterator<any>
 function concat(...iterables: Array<AnyIterable<any>>): AsyncIterableIterator<any>
 ```
 
-Combine multiple iterators into a single iterable. Reads each iterable completely one at a time. Returns a sync iterator if all `iterables` are sync otherwise an async iterable.
+Combine multiple iterators into a single iterable. Reads each iterable completely one at a time. Returns a sync iterator if all `iterables` are sync, otherwise it returns an async iterable.
 
 ```ts
 import { concat } from 'streaming-iterables'
@@ -413,14 +413,14 @@ Reduces an iterable to a value which is the accumulated result of running each v
 function take<T>(count: number, iterable: AnyIterable<T>): AsyncIterableIterator<T>
 ```
 
-Return a new iterator that reads a specific number of items from `iterable`.
+Returns a new iterator that reads a specific number of items from `iterable`.
 
 ### tap
 ```ts
 function tap<T>(func: (data: T) => any, iterable: AnyIterable<T>): AsyncIterableIterator<T>
 ```
 
-Return a new iterator that yields the data it consumes passing the data through to a function. If you provide an async function the iterator will wait for the promise to resolve before yielding the value. This is useful for logging, or processing information and passing it along.
+Returns a new iterator that yields the data it consumes passing the data through to a function. If you provide an async function the iterator will wait for the promise to resolve before yielding the value. This is useful for logging, or processing information and passing it along.
 
 ### transform
 ```ts

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ if ((Symbol as any).asyncIterator === undefined) {
 
 ### batch
 ```ts
-function batch<t>(size: number, iterable: AnyIterable<T>): AsyncIterableIterator<T[]>
+function batch<T>(size: number, iterable: AsyncIterable<T>): AsyncIterableIterator<T[]>
+function batch<T>(size: number, iterable: Iterable<T>): IterableIterator<T[]>
 ```
 
-Batch objects from `iterable` into arrays of `size` length. The final array may be shorter than size if there is not enough items.
+Batch objects from `iterable` into arrays of `size` length. The final array may be shorter than size if there is not enough items. Returns a sync iterator if the `iterable` is sync, otherwise an async iterator.
 
 ```ts
 import { batch } from 'streaming-iterables'
@@ -122,10 +123,11 @@ for await (const monster of buffer(10, getPokemon())) {
 
 ### collect
 ```ts
-function collect<T>(iterable: AnyIterable<T>): Promise<T[]>
+function collect<T>(iterable: Iterable<T>): T[]
+function collect<T>(iterable: AsyncIterable<T>): Promise<T[]>
 ```
 
-Collect all the values from an iterable into an array.
+Collect all the values from an iterable into an array. Returns an array if you pass it an iterable and a promise for an array if you pass it an async iterable.
 
 ```ts
 import { collect } from 'streaming-iterables'
@@ -137,10 +139,11 @@ console.log(await collect(getPokemon()))
 
 ### concat
 ```ts
+function concat(...iterables: Array<Iterable<any>>): IterableIterator<any>
 function concat(...iterables: Array<AnyIterable<any>>): AsyncIterableIterator<any>
 ```
 
-Combine multiple iterators into a single iterable. Reads each iterable one at a time.
+Combine multiple iterators into a single iterable. Reads each iterable completely one at a time. Returns a sync iterator if all `iterables` are sync otherwise an async iterable.
 
 ```ts
 import { concat } from 'streaming-iterables'
@@ -157,7 +160,8 @@ for await (const hero of concat(getPokemon(2), getTransformers(2))) {
 
 ### consume
 ```ts
-function consume<T>(iterator: AnyIterable<T>): Promise<void>
+export function consume<T>(iterator: Iterable<T>): void
+export function consume<T>(iterator: AsyncIterable<T>): Promise<void>
 ```
 
 A promise that resolves after the function drains the iterable of all data. Useful for processing a pipeline of data.
@@ -409,14 +413,14 @@ Reduces an iterable to a value which is the accumulated result of running each v
 function take<T>(count: number, iterable: AnyIterable<T>): AsyncIterableIterator<T>
 ```
 
-A passthrough iterator that reads a specific number of items from an iterator.
+Return a new iterator that reads a specific number of items from `iterable`.
 
 ### tap
 ```ts
 function tap<T>(func: (data: T) => any, iterable: AnyIterable<T>): AsyncIterableIterator<T>
 ```
 
-A passthrough iterator that yields the data it consumes passing the data through to a function. If you provide an async function the iterator will wait for the promise to resolve before yielding the value. This is useful for logging, or processing information and passing it along.
+Return a new iterator that yields the data it consumes passing the data through to a function. If you provide an async function the iterator will wait for the promise to resolve before yielding the value. This is useful for logging, or processing information and passing it along.
 
 ### transform
 ```ts

--- a/lib/batch-test.ts
+++ b/lib/batch-test.ts
@@ -31,7 +31,7 @@ describe('batch', () => {
     assert.deepEqual(batchs, [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
   })
 
-  it('buffers sync iterators', async () => {
+  it('batches sync iterators', async () => {
     const batchs: number[][] = []
     for await (const numberBatch of batch(5, numbers(10))) {
       assert.equal(numberBatch.length, 5)

--- a/lib/batch.ts
+++ b/lib/batch.ts
@@ -1,6 +1,4 @@
-import { AnyIterable } from './types'
-
-async function* _batch<T>(size: number, iterable: AnyIterable<T>) {
+async function* _batch<T>(size: number, iterable: AsyncIterable<T>) {
   let dataBatch: T[] = []
   for await (const data of iterable) {
     dataBatch.push(data)
@@ -14,11 +12,34 @@ async function* _batch<T>(size: number, iterable: AnyIterable<T>) {
   }
 }
 
-export function batch(size: number): <T>(curriedIterable: AnyIterable<T>) => AsyncIterableIterator<T[]>
-export function batch<T>(size: number, iterable: AnyIterable<T>): AsyncIterableIterator<T[]>
-export function batch<T>(size: number, iterable?: AnyIterable<T>) {
-  if (iterable === undefined) {
-    return (curriedIterable: AnyIterable<T>) => _batch(size, curriedIterable)
+function* _syncBatch<T>(size: number, iterable: Iterable<T>) {
+  let dataBatch: T[] = []
+  for (const data of iterable) {
+    dataBatch.push(data)
+    if (dataBatch.length === size) {
+      yield dataBatch
+      dataBatch = []
+    }
   }
-  return _batch(size, iterable)
+  if (dataBatch.length > 0) {
+    yield dataBatch
+  }
+}
+
+export function batch(
+  size: number
+): {
+  <T>(curriedIterable: AsyncIterable<T>): AsyncIterableIterator<T[]>
+  <T>(curriedIterable: Iterable<T>): IterableIterator<T[]>
+}
+export function batch<T>(size: number, iterable: AsyncIterable<T>): AsyncIterableIterator<T[]>
+export function batch<T>(size: number, iterable: Iterable<T>): IterableIterator<T[]>
+export function batch<T>(size: number, iterable?: Iterable<T> | AsyncIterable<T>) {
+  if (iterable === undefined) {
+    return curriedIterable => batch(size, curriedIterable)
+  }
+  if (iterable[Symbol.asyncIterator]) {
+    return _batch(size, iterable as AsyncIterable<T>)
+  }
+  return _syncBatch(size, iterable as Iterable<T>)
 }

--- a/lib/collect-test.ts
+++ b/lib/collect-test.ts
@@ -12,6 +12,6 @@ describe('collect', () => {
     assert.deepEqual(await collect(asyncIterable([1, 2, 3, 4])), [1, 2, 3, 4])
   })
   it('collects sync iterable data', async () => {
-    assert.deepEqual(await collect([1, 2, 3, 4]), [1, 2, 3, 4])
+    assert.deepEqual(collect([1, 2, 3, 4]), [1, 2, 3, 4])
   })
 })

--- a/lib/collect.ts
+++ b/lib/collect.ts
@@ -1,8 +1,25 @@
 import { AnyIterable } from './types'
-export async function collect<T>(iterable: AnyIterable<T>) {
+async function _collect<T>(iterable: AsyncIterable<T>) {
   const values: T[] = []
   for await (const value of iterable) {
     values.push(value)
   }
   return values
+}
+
+function _syncCollect<T>(iterable: Iterable<T>) {
+  const values: T[] = []
+  for (const value of iterable) {
+    values.push(value)
+  }
+  return values
+}
+
+export function collect<T>(iterable: Iterable<T>): T[]
+export function collect<T>(iterable: AsyncIterable<T>): Promise<T[]>
+export function collect<T>(iterable: AnyIterable<T>) {
+  if (iterable[Symbol.asyncIterator]) {
+    return _collect(iterable as AsyncIterable<T>)
+  }
+  return _syncCollect(iterable as Iterable<T>)
 }

--- a/lib/concat-test.ts
+++ b/lib/concat-test.ts
@@ -20,7 +20,7 @@ describe('concat', () => {
     }
     assert.deepEqual(collect(concat(one(), two())), [1, 2])
   })
-  it('concatenates mixed iterables', async () => {
+  it('concatenates mixed sync and async iterables', async () => {
     function* one() {
       yield 1
     }

--- a/lib/concat-test.ts
+++ b/lib/concat-test.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai'
 import { collect, concat } from './'
 
 describe('concat', () => {
-  it('concatenates multiple async iterators', async () => {
+  it('concatenates multiple async iterables', async () => {
     async function* one() {
       yield 1
     }
@@ -11,16 +11,22 @@ describe('concat', () => {
     }
     assert.deepEqual(await collect(concat(one(), two())), [1, 2])
   })
-  it('concatenates multiple sync iterators', async () => {
+  it('concatenates multiple sync iterables', async () => {
     function* one() {
       yield 1
     }
     function* two() {
       yield 2
     }
-    assert.deepEqual(await collect(concat(one(), two())), [1, 2])
+    assert.deepEqual(collect(concat(one(), two())), [1, 2])
   })
-  it('concatenates sync iterables', async () => {
-    assert.deepEqual(await collect(concat([1], [2], [3], [4])), [1, 2, 3, 4])
+  it('concatenates mixed iterables', async () => {
+    function* one() {
+      yield 1
+    }
+    async function* two() {
+      yield 2
+    }
+    assert.deepEqual(await collect(concat(one(), two())), [1, 2])
   })
 })

--- a/lib/concat.ts
+++ b/lib/concat.ts
@@ -1,8 +1,27 @@
 import { AnyIterable } from './types'
-export async function* concat(...iterables: Array<AnyIterable<any>>) {
+async function* _concat(iterables: Array<AnyIterable<any>>) {
   for await (const iterable of iterables) {
     for await (const value of iterable) {
       yield value
     }
+  }
+}
+
+function* _syncConcat(iterables: Array<Iterable<any>>) {
+  for (const iterable of iterables) {
+    for (const value of iterable) {
+      yield value
+    }
+  }
+}
+
+export function concat(...iterables: Array<Iterable<any>>): IterableIterator<any>
+export function concat(...iterables: Array<AnyIterable<any>>): AsyncIterableIterator<any>
+export function concat(...iterables: Array<AnyIterable<any>>) {
+  const hasAsync = iterables.find(itr => itr[Symbol.asyncIterator] !== undefined)
+  if (hasAsync) {
+    return _concat(iterables)
+  } else {
+    return _syncConcat(iterables as Array<Iterable<any>>)
   }
 }

--- a/lib/consume-test.ts
+++ b/lib/consume-test.ts
@@ -26,7 +26,7 @@ describe('consume', () => {
       }
     }
     assert.equal(num, 0)
-    await consume(numbers())
+    consume(numbers())
     assert.equal(num, 10)
   })
 })

--- a/lib/consume.ts
+++ b/lib/consume.ts
@@ -1,6 +1,17 @@
 import { AnyIterable } from './types'
-export async function consume<T>(iterator: AnyIterable<T>) {
+export async function _consume<T>(iterator: AnyIterable<T>) {
   for await (const val of iterator) {
+    // do nothing
+  }
+}
+
+export function consume<T>(iterator: Iterable<T>): void
+export function consume<T>(iterator: AsyncIterable<T>): Promise<void>
+export function consume<T>(iterator: AnyIterable<T>) {
+  if (iterator[Symbol.asyncIterator]) {
+    return _consume(iterator)
+  }
+  for (const val of iterator as Iterable<T>) {
     // do nothing
   }
 }


### PR DESCRIPTION
This is fun because the types tell you when you have to use await. If you don't know if what you have is sync or async it's always safe to use `await`