### PR TITLE
chore: benchmark streams against iterators

### DIFF
--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -182,4 +182,4 @@ suite.on('complete', function() {
   console.log('Fastest is ' + this.filter('fastest').map('name'))
 })
 
-suite.run({ async: true })
+suite.run()

--- a/benchmark/streams.ts
+++ b/benchmark/streams.ts
@@ -1,0 +1,148 @@
+import { Suite } from 'benchmark'
+import { consume, map, pipeline, tap, fromStream } from '../'
+import { Readable, PassThrough, Transform } from 'stream'
+const suite = new Suite()
+
+const asyncSetImmediate = () => {
+  return new Promise(resolve => {
+    setImmediate(resolve)
+  })
+}
+
+const numbersLimit = 10000
+
+const slowNumbers = () => {
+  let num = 0
+  return new Readable({
+    objectMode: true,
+    async read() {
+      await asyncSetImmediate()
+      if (num > numbersLimit) {
+        this.push(null)
+        return
+      }
+      this.push(++num)
+    },
+  })
+}
+
+const fastNumbers = () => {
+  let num = 0
+  return new Readable({
+    objectMode: true,
+    read() {
+      if (num > numbersLimit) {
+        this.push(null)
+        return
+      }
+      this.push(++num)
+    },
+  })
+}
+
+const fastStringify = i => [String(i)]
+const slowStringify = i => asyncSetImmediate().then(() => [String(i)])
+
+suite.add('tap slow source', {
+  defer: true,
+  fn: async deferred => {
+    await pipeline(() => fromStream(slowNumbers()), tap(fastStringify), consume)
+    deferred.resolve()
+  },
+})
+
+suite.add('stream tap slow source (PassThrough)', {
+  defer: true,
+  fn: async deferred => {
+    const passThrough = new PassThrough({
+      objectMode: true,
+      transform(num, encoding, cb) {
+        fastStringify(num)
+        cb(undefined, num)
+      },
+    })
+    slowNumbers().pipe(passThrough)
+    await pipeline(() => fromStream(passThrough), consume)
+    deferred.resolve()
+  },
+})
+
+suite.add('tap fast source', {
+  defer: true,
+  fn: async deferred => {
+    await pipeline(() => fromStream(fastNumbers()), tap(fastStringify), consume)
+    deferred.resolve()
+  },
+})
+
+suite.add('stream tap fast source (PassThrough)', {
+  defer: true,
+  fn: async deferred => {
+    const passThrough = new PassThrough({
+      objectMode: true,
+      transform(num, encoding, cb) {
+        fastStringify(num)
+        cb(undefined, num)
+      },
+    })
+    fastNumbers().pipe(passThrough)
+    await pipeline(() => fromStream(passThrough), consume)
+    deferred.resolve()
+  },
+})
+
+suite.add('map slow source', {
+  defer: true,
+  fn: async deferred => {
+    await pipeline(() => fromStream(slowNumbers()), map(slowStringify), consume)
+    deferred.resolve()
+  },
+})
+
+suite.add('stream map slow source (transform)', {
+  defer: true,
+  fn: async deferred => {
+    const transformStream = new Transform({
+      objectMode: true,
+      transform(num, encoding, cb) {
+        slowStringify(num).then(str => cb(undefined, str))
+      },
+    })
+    slowNumbers().pipe(transformStream)
+    await pipeline(() => fromStream(transformStream), consume)
+    deferred.resolve()
+  },
+})
+
+suite.add('map fast source', {
+  defer: true,
+  fn: async deferred => {
+    await pipeline(() => fromStream(fastNumbers()), map(slowStringify), consume)
+    deferred.resolve()
+  },
+})
+
+suite.add('stream map fast source (transform)', {
+  defer: true,
+  fn: async deferred => {
+    const transformStream = new Transform({
+      objectMode: true,
+      transform(num, encoding, cb) {
+        slowStringify(num).then(str => cb(undefined, str))
+      },
+    })
+    fastNumbers().pipe(transformStream)
+    await pipeline(() => fromStream(transformStream), consume)
+    deferred.resolve()
+  },
+})
+
+suite.on('cycle', event => {
+  console.log(String(event.target))
+})
+
+suite.on('complete', function() {
+  console.log('Fastest is ' + this.filter('fastest').map('name'))
+})
+
+suite.run()


### PR DESCRIPTION
They're about the same when processing data! Quite the same when processing slow data! When doing nothing, passthrough is faster than tap.

```
tap slow source x 19.60 ops/sec ±5.07% (50 runs sampled)
stream tap slow source (PassThrough) x 21.27 ops/sec ±3.77% (53 runs sampled)
tap fast source x 81.60 ops/sec ±1.73% (74 runs sampled)
stream tap fast source (PassThrough) x 164 ops/sec ±1.06% (77 runs sampled)
map slow source x 20.19 ops/sec ±1.98% (51 runs sampled)
stream map slow source (transform) x 19.98 ops/sec ±3.62% (51 runs sampled)
map fast source x 21.42 ops/sec ±1.80% (53 runs sampled)
stream map fast source (transform) x 22.32 ops/sec ±3.18% (55 runs sampled)
```