### PR TITLE
feat: Error handling is now more intelligent

### DIFF
--- a/lib/batch-test.ts
+++ b/lib/batch-test.ts
@@ -1,9 +1,6 @@
 import { assert } from 'chai'
 import { batch } from './'
-
-function promiseImmediate<T>(data?: T): Promise<T> {
-  return new Promise(resolve => setImmediate(() => resolve(data)))
-}
+import { promiseImmediate } from './util-test'
 
 async function* asyncNumbers(max: number) {
   let num = 1

--- a/lib/collect-test.ts
+++ b/lib/collect-test.ts
@@ -1,15 +1,10 @@
 import { assert } from 'chai'
 import { collect } from './'
-
-async function* asyncIterable(arr) {
-  for (const val of arr) {
-    yield val
-  }
-}
+import { asyncFromArray } from './util-test'
 
 describe('collect', () => {
   it('collects async iterable data', async () => {
-    assert.deepEqual(await collect(asyncIterable([1, 2, 3, 4])), [1, 2, 3, 4])
+    assert.deepEqual(await collect(asyncFromArray([1, 2, 3, 4])), [1, 2, 3, 4])
   })
   it('collects sync iterable data', async () => {
     assert.deepEqual(collect([1, 2, 3, 4]), [1, 2, 3, 4])

--- a/lib/consume-test.ts
+++ b/lib/consume-test.ts
@@ -1,9 +1,6 @@
 import { assert } from 'chai'
 import { consume } from './'
-
-function promiseImmediate<T>(data?: T): Promise<T> {
-  return new Promise(resolve => setImmediate(() => resolve(data)))
-}
+import { promiseImmediate } from './util-test'
 
 describe('consume', () => {
   it('consumes the entire async iterator', async () => {

--- a/lib/consume.ts
+++ b/lib/consume.ts
@@ -1,17 +1,17 @@
 import { AnyIterable } from './types'
-export async function _consume<T>(iterator: AnyIterable<T>) {
-  for await (const val of iterator) {
+export async function _consume<T>(iterable: AnyIterable<T>) {
+  for await (const val of iterable) {
     // do nothing
   }
 }
 
-export function consume<T>(iterator: Iterable<T>): void
-export function consume<T>(iterator: AsyncIterable<T>): Promise<void>
-export function consume<T>(iterator: AnyIterable<T>) {
-  if (iterator[Symbol.asyncIterator]) {
-    return _consume(iterator)
+export function consume<T>(iterable: Iterable<T>): void
+export function consume<T>(iterable: AsyncIterable<T>): Promise<void>
+export function consume<T>(iterable: AnyIterable<T>) {
+  if (iterable[Symbol.asyncIterator]) {
+    return _consume(iterable)
   }
-  for (const val of iterator as Iterable<T>) {
+  for (const val of iterable as Iterable<T>) {
     // do nothing
   }
 }

--- a/lib/defer.ts
+++ b/lib/defer.ts
@@ -1,0 +1,19 @@
+export function defer<T>(): IDeferred<T> {
+  let reject
+  let resolve
+  const promise = new Promise<T>((resolveFunc, rejectFunc) => {
+    resolve = resolveFunc
+    reject = rejectFunc
+  })
+  return {
+    promise,
+    reject,
+    resolve,
+  }
+}
+
+export interface IDeferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: Error) => void
+}

--- a/lib/filter-test.ts
+++ b/lib/filter-test.ts
@@ -1,12 +1,6 @@
 import { assert } from 'chai'
 import { filter } from './'
-import { AnyIterable } from './types'
-
-async function* asyncValues<T>(values: AnyIterable<T>) {
-  for await (const value of values) {
-    yield value
-  }
-}
+import { asyncFromArray } from './util-test'
 
 describe('filter', () => {
   it('filters iterators', async () => {
@@ -18,7 +12,7 @@ describe('filter', () => {
   })
   it('filters async iterators', async () => {
     const numbers: number[] = []
-    for await (const num of filter(i => !!i, asyncValues([1, 2, null, undefined, 3]))) {
+    for await (const num of filter(i => !!i, asyncFromArray([1, 2, null, undefined, 3]))) {
       numbers.push(num as number)
     }
     assert.deepEqual(numbers, [1, 2, 3])
@@ -33,7 +27,7 @@ describe('filter', () => {
 
   it('is curryable', async () => {
     const numbers: number[] = []
-    const values = asyncValues([1, 2, null, 3])
+    const values = asyncFromArray([1, 2, null, 3])
     const filterFalsy = filter(i => !!i)
     for await (const num of filterFalsy(values)) {
       numbers.push(num as number)

--- a/lib/flat-map-test.ts
+++ b/lib/flat-map-test.ts
@@ -1,12 +1,6 @@
 import { assert } from 'chai'
 import { flatMap } from '.'
-import { AnyIterable } from './types'
-
-async function* asyncValues<T>(values: AnyIterable<T>) {
-  for await (const value of values) {
-    yield value
-  }
-}
+import { asyncFromArray } from './util-test'
 
 describe('flatmap', () => {
   it('flattens arrays', async () => {
@@ -19,7 +13,7 @@ describe('flatmap', () => {
 
   it('flattens async and sync iterables', async () => {
     const numbers: number[] = []
-    const values = asyncValues([1, 2, asyncValues([3, 4, 5, 6]), 7, [8]])
+    const values = asyncFromArray([1, 2, asyncFromArray([3, 4, 5, 6]), 7, [8]])
     for await (const num of flatMap(i => i, values)) {
       numbers.push(num)
     }
@@ -27,7 +21,7 @@ describe('flatmap', () => {
   })
   it('ignores null and undefined values', async () => {
     const numbers: number[] = []
-    const values = asyncValues([1, undefined, null, 2, asyncValues([3, 4, undefined, 5, 6]), 7, [8], null])
+    const values = asyncFromArray([1, undefined, null, 2, asyncFromArray([3, 4, undefined, 5, 6]), 7, [8], null])
     for await (const num of flatMap(i => i, values)) {
       numbers.push(num as number)
     }

--- a/lib/flatten-test.ts
+++ b/lib/flatten-test.ts
@@ -1,13 +1,7 @@
 import { assert } from 'chai'
 import { flatten } from './'
-import { AnyIterable } from './types'
 import { collect } from './collect'
-
-async function* asyncValues<T>(values: AnyIterable<T>) {
-  for await (const value of values) {
-    yield value
-  }
-}
+import { asyncFromArray } from './util-test'
 
 describe('flatten', () => {
   it('flattens arrays', async () => {
@@ -20,7 +14,7 @@ describe('flatten', () => {
 
   it('flattens async and sync iterables', async () => {
     const numbers: number[] = []
-    const values = asyncValues([1, 2, asyncValues([3, [4], asyncValues([5]), 6]), 7, [8]])
+    const values = asyncFromArray([1, 2, asyncFromArray([3, [4], asyncFromArray([5]), 6]), 7, [8]])
     for await (const num of flatten(values as any)) {
       numbers.push(num as number)
     }

--- a/lib/flatten.ts
+++ b/lib/flatten.ts
@@ -3,9 +3,7 @@ import { AnyIterable } from './types'
 export async function* flatten<B>(iterable: AnyIterable<B | AnyIterable<B>>): AsyncIterableIterator<B> {
   for await (const maybeItr of iterable) {
     if (maybeItr && typeof maybeItr !== 'string' && (maybeItr[Symbol.iterator] || maybeItr[Symbol.asyncIterator])) {
-      for await (const item of flatten(maybeItr as AnyIterable<B>)) {
-        yield item
-      }
+      yield* flatten(maybeItr as AnyIterable<B>)
     } else {
       yield maybeItr as B
     }

--- a/lib/map-test.ts
+++ b/lib/map-test.ts
@@ -1,9 +1,6 @@
 import { assert } from 'chai'
 import { map } from './'
-
-async function asyncString(str) {
-  return String(str)
-}
+import { makeDelay, asyncString } from './util-test'
 
 describe('map', () => {
   it('iterates a sync function over an async value', async () => {
@@ -41,5 +38,24 @@ describe('map', () => {
       values.push(val)
     }
     assert.deepEqual(values, ['1', '2', '3'])
+  })
+  it('propagates source errors after the transforms have finished', async () => {
+    async function* source() {
+      yield 1
+      yield 2
+      yield 3
+      throw new Error('All done!')
+    }
+    const itr = map(makeDelay(10), source())[Symbol.asyncIterator]()
+    assert.equal((await itr.next()).value, 1)
+    assert.equal((await itr.next()).value, 2)
+    assert.equal((await itr.next()).value, 3)
+    try {
+      await itr.next()
+      throw new Error('next should have errored')
+    } catch (error) {
+      assert.equal(error.message, 'All done!')
+    }
+    assert.deepEqual((await itr.next()) as any, { done: true, value: undefined })
   })
 })

--- a/lib/merge-test.ts
+++ b/lib/merge-test.ts
@@ -1,9 +1,6 @@
 import { assert } from 'chai'
 import { merge } from './'
-
-function promiseImmediate<T>(data?: T): Promise<T> {
-  return new Promise(resolve => setImmediate(() => resolve(data)))
-}
+import { promiseImmediate } from './util-test'
 
 function* numbers() {
   yield 1

--- a/lib/parallel-flat-map-test.ts
+++ b/lib/parallel-flat-map-test.ts
@@ -1,10 +1,7 @@
 import { assert } from 'chai'
 import { parallelFlatMap, fromStream } from './'
 import { PassThrough } from 'stream'
-
-async function asyncStringArr(str) {
-  return [String(str)]
-}
+import { asyncStringArr, delayTicks } from './util-test'
 
 describe('parallelFlatMap', () => {
   it('iterates a sync function over an async value', async () => {
@@ -50,7 +47,8 @@ describe('parallelFlatMap', () => {
     const iterable = parallelFlatMap(3, counter, [1, 2, 3, 4, 5, 6])
     const itr = iterable[Symbol.asyncIterator]()
     await itr.next()
-    assert.equal(mapCount, 3)
+    await delayTicks(5)
+    await assert.equal(mapCount, 4)
   })
   it('can have a concurrency more than the items in a stream', async () => {
     const stream = new PassThrough()

--- a/lib/parallel-merge-test.ts
+++ b/lib/parallel-merge-test.ts
@@ -1,10 +1,7 @@
 import { assert } from 'chai'
 import { parallelMerge, fromStream } from './'
 import { PassThrough } from 'stream'
-
-function promiseImmediate<T>(data?: T): Promise<T> {
-  return new Promise(resolve => setImmediate(() => resolve(data)))
-}
+import { promiseImmediate } from './util-test'
 
 function* numbers() {
   yield 4

--- a/lib/reduce-test.ts
+++ b/lib/reduce-test.ts
@@ -1,9 +1,6 @@
 import { assert } from 'chai'
 import { reduce } from './'
-
-function promiseImmediate<T>(data?: T): Promise<T> {
-  return new Promise(resolve => setImmediate(() => resolve(data)))
-}
+import { promiseImmediate } from './util-test'
 
 function* numbers() {
   yield 1

--- a/lib/tap-test.ts
+++ b/lib/tap-test.ts
@@ -1,16 +1,13 @@
 import { assert } from 'chai'
 import { tap } from './'
 import { map } from './map'
-
-function resolveLater<T>(data?: T) {
-  return new Promise(resolve => setImmediate(() => resolve(data))) as Promise<T>
-}
+import { promiseImmediate } from './util-test'
 
 describe('tap', () => {
   it('iterates a sync function over an async value', async () => {
     const logs: number[] = []
     const log = tap<number>(data => logs.push(data))
-    const asyncNumbers = map<number, number>(num => resolveLater(num), [1, 2, 3])
+    const asyncNumbers = map<number, number>(num => promiseImmediate(num), [1, 2, 3])
     const values: any[] = []
     for await (const val of log(asyncNumbers)) {
       values.push(val)
@@ -32,10 +29,10 @@ describe('tap', () => {
   it('iterates an async function over an async value', async () => {
     const logs: any[] = []
     const log = tap<number>(async data => {
-      await resolveLater()
+      await promiseImmediate()
       logs.push(data)
     })
-    const asyncNumbers = map<number, number>(num => resolveLater(num), [1, 2, 3])
+    const asyncNumbers = map<number, number>(num => promiseImmediate(num), [1, 2, 3])
     const values: any[] = []
     for await (const val of log(asyncNumbers)) {
       values.push(val)
@@ -46,7 +43,7 @@ describe('tap', () => {
   it('iterates an async function over a sync value', async () => {
     const logs: any[] = []
     const log = tap<number>(async data => {
-      await resolveLater()
+      await promiseImmediate()
       logs.push(data)
     })
     const syncNumbers = [1, 2, 3]

--- a/lib/transform.ts
+++ b/lib/transform.ts
@@ -1,35 +1,6 @@
 import { AnyIterable } from './types'
 import { getIterator } from './get-iterator'
-import { pipeline } from './pipeline'
-import { buffer } from './buffer'
-import { map } from './map'
-
-interface IDeferred {
-  promise: Promise<any>
-  resolve: (value?: any) => void
-  reject: (error?: Error) => void
-}
-
-function defer<T>() {
-  let reject
-  let resolve
-  const promise = new Promise<T>((resolveFunc, rejectFunc) => {
-    resolve = resolveFunc
-    reject = rejectFunc
-  })
-  return {
-    promise,
-    reject,
-    resolve,
-  }
-}
-
-function endReadQueue(readQueue, endValue) {
-  while (readQueue.length > 0) {
-    const { resolve } = readQueue.shift() as IDeferred
-    resolve(endValue)
-  }
-}
+import { defer, IDeferred } from './defer'
 
 function _transform<T, R>(
   concurrency: number,
@@ -38,58 +9,86 @@ function _transform<T, R>(
 ): AsyncIterableIterator<R> {
   const iterator = getIterator(iterable)
 
-  const valueQueue: Array<IteratorResult<R>> = []
-  const readQueue: IDeferred[] = []
+  const resultQueue: R[] = []
+  const readQueue: Array<IDeferred<IteratorResult<R>>> = []
 
-  let endValue: null | IteratorResult<T> = null
+  let ended = false
   let reading = false
   let inflightCount = 0
+  let lastError: Error | null = null
 
-  function fillQueue() {
-    if (inflightCount + valueQueue.length >= concurrency) {
+  function fulfillReadQueue() {
+    while (readQueue.length > 0 && resultQueue.length > 0) {
+      const { resolve } = readQueue.shift() as IDeferred<IteratorResult<R>>
+      const value = resultQueue.shift() as R
+      resolve({ done: false, value } as any)
+    }
+    while (readQueue.length > 0 && inflightCount === 0 && ended) {
+      const { resolve, reject } = readQueue.shift() as IDeferred<IteratorResult<R>>
+      if (lastError) {
+        reject(lastError)
+        lastError = null
+      } else {
+        resolve({ done: true, value: undefined } as any)
+      }
+    }
+  }
+
+  async function fillQueue() {
+    if (ended) {
+      fulfillReadQueue()
       return
     }
-    if (endValue && inflightCount === 0 && valueQueue.length === 0) {
-      endReadQueue(readQueue, endValue)
+    if (reading) {
       return
     }
-    if (reading === true) {
+    if (inflightCount + resultQueue.length >= concurrency) {
       return
     }
     reading = true
     inflightCount++
-    Promise.resolve(iterator.next()).then(async ({ done, value }) => {
+    try {
+      const { done, value } = await iterator.next()
       if (done) {
-        endValue = { done, value }
+        ended = true
         inflightCount--
-        fillQueue()
-        return
-      }
-      reading = false
-      fillQueue()
-      const transformedValue = await func(value)
-      inflightCount--
-      const result = { value: transformedValue, done: false }
-      if (readQueue.length > 0) {
-        const readDeferred = readQueue.shift() as IDeferred
-        readDeferred.resolve(result)
+        fulfillReadQueue()
       } else {
-        valueQueue.push(result)
+        mapAndQueue(value)
       }
-      fillQueue()
-    })
+    } catch (error) {
+      ended = true
+      inflightCount--
+      lastError = error
+      fulfillReadQueue()
+    }
+    reading = false
+    fillQueue()
+  }
+
+  async function mapAndQueue(itrValue: T) {
+    try {
+      const value = await func(itrValue)
+      resultQueue.push(value)
+    } catch (error) {
+      ended = true
+      lastError = error
+    }
+    inflightCount--
+    fulfillReadQueue()
+    fillQueue()
   }
 
   async function next() {
-    if (valueQueue.length === 0) {
+    if (resultQueue.length === 0) {
       const deferred = defer<IteratorResult<R>>()
       readQueue.push(deferred)
       fillQueue()
       return deferred.promise
     }
-    const value = valueQueue.shift() as IteratorResult<R>
+    const value = resultQueue.shift() as R
     fillQueue()
-    return value
+    return { done: false, value }
   }
 
   const asyncIterableIterator = {

--- a/lib/util-test.ts
+++ b/lib/util-test.ts
@@ -1,0 +1,27 @@
+export async function asyncString(str) {
+  return String(str)
+}
+
+export async function asyncStringArr(str) {
+  return [String(str)]
+}
+
+export function promiseImmediate<T>(data?: T) {
+  return new Promise(resolve => setImmediate(() => resolve(data))) as Promise<T>
+}
+
+export async function delayTicks<T>(count = 1, data?: T) {
+  for (let i = 0; i < count; i++) {
+    await promiseImmediate()
+  }
+  return data
+}
+
+export const makeDelay = count => data => delayTicks(count, data)
+
+export async function* asyncFromArray<T>(arr: T[]) {
+  for (const value of arr) {
+    await promiseImmediate()
+    yield value
+  }
+}

--- a/lib/write-to-stream-test.ts
+++ b/lib/write-to-stream-test.ts
@@ -1,12 +1,7 @@
 import { assert } from 'chai'
 import { writeToStream } from './'
 import { PassThrough, Transform } from 'stream'
-
-function asyncImmediate() {
-  return new Promise(resolve => {
-    setImmediate(() => resolve())
-  })
-}
+import { promiseImmediate } from './util-test'
 
 describe('writeToStream', () => {
   it('writes values to a stream', async () => {
@@ -40,13 +35,13 @@ describe('writeToStream', () => {
         cb(null, value)
       },
     })
-    const writePromise = writeToStream(stream, values())
+    writeToStream(stream, values())
     assert.isNull(stream.read())
-    await asyncImmediate()
+    await promiseImmediate()
     assert.isAtMost(lastYield, 2)
     assert.equal(lastWrite, 1)
     assert.equal(stream.read(), 1)
-    await asyncImmediate()
+    await promiseImmediate()
     assert.equal(stream.read(), 2)
     assert.isAtMost(lastYield, 3)
     assert.equal(lastWrite, 2)


### PR DESCRIPTION
- fixes any unhandled promise rejections
- buffer() yields source errors after all buffered values are yielded
- cleanup tests and share test utilities
- errors are now handled by transform intelligently
- flatTransform is now much better at errors
- note error handling in docs
- perf is unchanged

```
async batch x 31.37 ops/sec ±3.19% (72 runs sampled)
async collect x 32.14 ops/sec ±1.70% (73 runs sampled)
async consume x 32.63 ops/sec ±0.84% (74 runs sampled)
async buffer x 28.21 ops/sec ±1.72% (66 runs sampled)
async flatTransform x 7.50 ops/sec ±2.59% (40 runs sampled)
async map x 14.48 ops/sec ±1.11% (68 runs sampled)
async map sync func x 25.44 ops/sec ±0.75% (60 runs sampled)
async parallelFlatMap x 5.94 ops/sec ±1.72% (33 runs sampled)
async parallelMap x 13.81 ops/sec ±1.09% (65 runs sampled)
async parallelMap sync func x 14.14 ops/sec ±1.22% (66 runs sampled)
async tap x 14.55 ops/sec ±1.23% (68 runs sampled)
async transform x 14.60 ops/sec ±1.24% (68 runs sampled)
async transform sync func x 25.22 ops/sec ±0.85% (60 runs sampled)
sync batch x 3,949 ops/sec ±0.48% (94 runs sampled)
sync collect x 5,674 ops/sec ±1.66% (93 runs sampled)
sync consume x 6,628 ops/sec ±0.85% (92 runs sampled)
sync buffer x 1,542 ops/sec ±1.74% (92 runs sampled)
```