### PR TITLE
feat: Improve types and perf!

### DIFF
--- a/lib/collect-test.ts
+++ b/lib/collect-test.ts
@@ -4,9 +4,14 @@ import { asyncFromArray } from './util-test'
 
 describe('collect', () => {
   it('collects async iterable data', async () => {
-    assert.deepEqual(await collect(asyncFromArray([1, 2, 3, 4])), [1, 2, 3, 4])
+    const value = await collect(asyncFromArray([1, 2, 3, 4]))
+    assert.deepEqual(value, [1, 2, 3, 4])
   })
   it('collects sync iterable data', async () => {
-    assert.deepEqual(collect([1, 2, 3, 4]), [1, 2, 3, 4])
+    function* numbers() {
+      yield* [1, 2, 3, 4]
+    }
+    const value = collect(numbers())
+    assert.deepEqual(value, [1, 2, 3, 4])
   })
 })

--- a/lib/collect.ts
+++ b/lib/collect.ts
@@ -1,4 +1,3 @@
-import { AnyIterable } from './types'
 async function _collect<T>(iterable: AsyncIterable<T>) {
   const values: T[] = []
   for await (const value of iterable) {
@@ -7,19 +6,11 @@ async function _collect<T>(iterable: AsyncIterable<T>) {
   return values
 }
 
-function _syncCollect<T>(iterable: Iterable<T>) {
-  const values: T[] = []
-  for (const value of iterable) {
-    values.push(value)
-  }
-  return values
-}
-
-export function collect<T>(iterable: Iterable<T>): T[]
 export function collect<T>(iterable: AsyncIterable<T>): Promise<T[]>
-export function collect<T>(iterable: AnyIterable<T>) {
+export function collect<T>(iterable: Iterable<T>): T[]
+export function collect<T>(iterable: any) {
   if (iterable[Symbol.asyncIterator]) {
     return _collect(iterable as AsyncIterable<T>)
   }
-  return _syncCollect(iterable as Iterable<T>)
+  return Array.from(iterable as Iterable<T>)
 }

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -9,7 +9,7 @@ export function map<T, B>(func: (data: T) => B | Promise<B>): (iterable: AnyIter
 export function map<T, B>(func: (data: T) => B | Promise<B>, iterable: AnyIterable<T>): AsyncIterableIterator<B>
 export function map<T, B>(func: (data: T) => B | Promise<B>, iterable?: AnyIterable<T>) {
   if (iterable === undefined) {
-    return (curriedIterable: AnyIterable<T>) => _map(func, curriedIterable)
+    return curriedIterable => _map(func, curriedIterable)
   }
   return _map(func, iterable)
 }

--- a/lib/parallel-map.ts
+++ b/lib/parallel-map.ts
@@ -14,7 +14,7 @@ async function* _parallelMap<T, R>(
     value: func(value),
   })
 
-  const stopOnError = async function*(source) {
+  const stopOnError = async function*<P>(source: AnyIterable<P>) {
     for await (const value of source) {
       if (transformError) {
         return
@@ -23,7 +23,7 @@ async function* _parallelMap<T, R>(
     }
   }
   const output = pipeline(() => iterable, buffer(1), stopOnError, map(wrapFunc), buffer(concurrency))
-  const itr = getIterator<{ value: Promise<R> | R }>(output)
+  const itr: AsyncIterator<{ value: Promise<R> | R }> = getIterator(output)
   while (true) {
     const { value, done } = await itr.next()
     if (done) {
@@ -60,13 +60,10 @@ export function parallelMap<T, R>(
 ): AsyncIterableIterator<R>
 export function parallelMap<T, R>(concurrency: number, func?: (data: T) => R | Promise<R>, iterable?: AnyIterable<T>) {
   if (func === undefined) {
-    return <A, B>(curriedFunc: (data: A) => B | Promise<B>, curriedIterable?: AnyIterable<A>) =>
-      curriedIterable
-        ? parallelMap<A, B>(concurrency, curriedFunc, curriedIterable)
-        : parallelMap<A, B>(concurrency, curriedFunc)
+    return (curriedFunc, curriedIterable) => parallelMap(concurrency, curriedFunc, curriedIterable)
   }
   if (iterable === undefined) {
-    return (curriedIterable: AnyIterable<T>) => parallelMap<T, R>(concurrency, func, curriedIterable)
+    return curriedIterable => parallelMap(concurrency, func, curriedIterable)
   }
   return _parallelMap(concurrency, func, iterable)
 }

--- a/lib/pipeline-test.ts
+++ b/lib/pipeline-test.ts
@@ -6,7 +6,11 @@ import { map } from './map'
 describe('reduce', () => {
   it('calls an argument list of functions', async () => {
     const getData = () => [1, 2, 3]
-    const makeString = map(i => String(i))
+    function* makeString(arr: number[]) {
+      for (const i of arr) {
+        yield String(i)
+      }
+    }
     const manual = await collect(makeString(getData()))
     const pipelined = await pipeline(getData, makeString, collect)
     assert.deepEqual(manual, pipelined)

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -1,5 +1,66 @@
-// tslint:disable-next-line:ban-types
-export function pipeline(firstFn: Function, ...fns: Function[]) {
+// export function pipeline<T>(firstFn: () => T, ...fns: Array<(arg: T) => T>): T
+export function pipeline<T0>(firstFn: () => T0): T0
+export function pipeline<T0, T1>(a0: () => T0, a1: (a: T0) => T1): T1
+export function pipeline<T0, T1, T2>(a0: () => T0, a1: (a: T0) => T1, a2: (a: T1) => T2): T2
+export function pipeline<T0, T1, T2, T3>(a0: () => T0, a1: (a: T0) => T1, a2: (a: T1) => T2, a3: (a: T2) => T3): T3
+export function pipeline<T0, T1, T2, T3, T4>(
+  a0: () => T0,
+  a1: (a: T0) => T1,
+  a2: (a: T1) => T2,
+  a3: (a: T2) => T3,
+  a4: (a: T3) => T4
+): T4
+export function pipeline<T0, T1, T2, T3, T4, T5>(
+  a0: () => T0,
+  a1: (a: T0) => T1,
+  a2: (a: T1) => T2,
+  a3: (a: T2) => T3,
+  a4: (a: T3) => T4,
+  a5: (a: T4) => T5
+): T5
+export function pipeline<T0, T1, T2, T3, T4, T5, T6>(
+  a0: () => T0,
+  a1: (a: T0) => T1,
+  a2: (a: T1) => T2,
+  a3: (a: T2) => T3,
+  a4: (a: T3) => T4,
+  a5: (a: T4) => T5,
+  a6: (a: T5) => T6
+): T6
+export function pipeline<T0, T1, T2, T3, T4, T5, T6, T7>(
+  a0: () => T0,
+  a1: (a: T0) => T1,
+  a2: (a: T1) => T2,
+  a3: (a: T2) => T3,
+  a4: (a: T3) => T4,
+  a5: (a: T4) => T5,
+  a6: (a: T5) => T6,
+  a7: (a: T6) => T7
+): T7
+export function pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8>(
+  a0: () => T0,
+  a1: (a: T0) => T1,
+  a2: (a: T1) => T2,
+  a3: (a: T2) => T3,
+  a4: (a: T3) => T4,
+  a5: (a: T4) => T5,
+  a6: (a: T5) => T6,
+  a7: (a: T6) => T7,
+  a8: (a: T7) => T8
+): T8
+export function pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+  a0: () => T0,
+  a1: (a: T0) => T1,
+  a2: (a: T1) => T2,
+  a3: (a: T2) => T3,
+  a4: (a: T3) => T4,
+  a5: (a: T4) => T5,
+  a6: (a: T5) => T6,
+  a7: (a: T6) => T7,
+  a8: (a: T7) => T8,
+  a9: (a: T8) => T9
+): T9
+export function pipeline(firstFn: any, ...fns: any[]) {
   let previousFn = firstFn()
   for (const func of fns) {
     previousFn = func(previousFn)

--- a/lib/take.ts
+++ b/lib/take.ts
@@ -22,15 +22,16 @@ function* _syncTake<T>(count: number, iterable: Iterable<T>) {
   }
 }
 
-export function take<T>(
-  count: number
-): {
-  (curriedIterable: AsyncIterable<T>): AsyncIterableIterator<T>
-  (curriedIterable: Iterable<T>): IterableIterator<T>
-}
-export function take<T>(count: number, iterable: AsyncIterable<T>): AsyncIterableIterator<T>
-export function take<T>(count: number, iterable: Iterable<T>): IterableIterator<T>
-export function take<T>(count: number, iterable?: AnyIterable<T>) {
+type UnwrapAnyIterable<M extends AnyIterable<any>> = M extends Iterable<infer T>
+  ? Iterable<T>
+  : M extends AsyncIterable<infer B>
+  ? AsyncIterable<B>
+  : never
+type CurriedTakeResult = <T, M extends AnyIterable<T>>(curriedIterable: M) => UnwrapAnyIterable<M>
+
+export function take(count: number): CurriedTakeResult
+export function take<T, M extends AnyIterable<T>>(count: number, iterable: M): UnwrapAnyIterable<M>
+export function take<T>(count: number, iterable?: AnyIterable<T>): CurriedTakeResult | UnwrapAnyIterable<any> {
   if (iterable === undefined) {
     return curriedIterable => take(count, curriedIterable)
   }

--- a/tslint.json
+++ b/tslint.json
@@ -7,19 +7,33 @@
     "jsRules": {},
     "rules": {
         "adjacent-overload-signatures": false,
-        "arrow-parens": [true, "ban-single-arg-parens"],
+        "arrow-parens": [
+            true,
+            "ban-single-arg-parens"
+        ],
         "max-line-length": false,
         "no-empty-interface": false,
+        "interface-over-type-literal": false,
         "no-empty": false,
         "ordered-imports": false,
-        "prettier": [true, {
-            "semi": false,
-            "singleQuote": true,
-            "printWidth": 120,
-            "trailingComma": "es5"
-        }],
-        "quotemark": [true, "single", "avoid-escape", "avoid-template"],
-        "trailing-comma": [false]
+        "prettier": [
+            true,
+            {
+                "semi": false,
+                "singleQuote": true,
+                "printWidth": 120,
+                "trailingComma": "es5"
+            }
+        ],
+        "quotemark": [
+            true,
+            "single",
+            "avoid-escape",
+            "avoid-template"
+        ],
+        "trailing-comma": [
+            false
+        ]
     },
     "rulesDirectory": [
         "tslint-plugin-prettier"


### PR DESCRIPTION
- pipeline now properly types arguments of calls up to 10 deep!
- collect now uses `Array.from` in it’s sync form
- take, buffer and batch now used mapped types to better resolve their output types! (Thanks to https://stackoverflow.com/a/55007827/339)