### PR TITLE
Improve how we ship TS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+dist-ts

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,8 @@ tsconfig-build.json
 tsconfig.json
 tslint.json
 benchmark
+dist-ts
+rollup.config-esm.js
+rollup.config-umd.js
+budle-types.js
+dist/tsdoc-metadata.json

--- a/bundle-types.js
+++ b/bundle-types.js
@@ -1,0 +1,33 @@
+const ApiExtractor = require("@microsoft/api-extractor")
+
+const config = {
+  $schema: "https://developer.microsoft.com/json-schemas/api-extractor/api-extractor.schema.json",
+  compiler: {
+    configType: "tsconfig",
+    rootFolder: "./"
+  },
+  project: {
+    entryPointSourceFile: "dist-ts/index.d.ts"
+  },
+  validationRules: {
+    missingReleaseTags: "allow"
+  },
+  dtsRollup: {
+    enabled: true,
+    publishFolder: "./",
+    mainDtsRollupPath: "dist/index.d.ts"
+  },
+  apiReviewFile: {
+    enabled: false
+  },
+  apiJsonFile: {
+    enabled: false
+  }
+}
+
+// This interface provides additional runtime state that is NOT part of the config file
+const options = {
+  // localBuild: process.argv.indexOf("--ship") < 0
+}
+const extractor = new ApiExtractor.Extractor(config, options)
+extractor.processProject()

--- a/lib/batch.ts
+++ b/lib/batch.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 
 async function* _batch<T>(size: number, iterable: AsyncIterable<T>) {

--- a/lib/buffer.ts
+++ b/lib/buffer.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { getIterator } from './get-iterator'
 import { defer, IDeferred } from './defer'
 import { AnyIterable } from './types'

--- a/lib/collect.ts
+++ b/lib/collect.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 async function _collect<T>(iterable: AsyncIterable<T>) {
   const values: T[] = []
   for await (const value of iterable) {

--- a/lib/concat.ts
+++ b/lib/concat.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 async function* _concat(iterables: Array<AnyIterable<any>>) {
   for await (const iterable of iterables) {

--- a/lib/consume.ts
+++ b/lib/consume.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 export async function _consume<T>(iterable: AnyIterable<T>) {
   for await (const val of iterable) {

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 
 async function* _filter<T>(filterFunc: (data: T) => boolean | Promise<boolean>, iterable: AnyIterable<T>) {

--- a/lib/flat-map.ts
+++ b/lib/flat-map.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable, FlatMapValue } from './types'
 import { flatten } from './flatten'
 import { filter } from './filter'

--- a/lib/flat-transform.ts
+++ b/lib/flat-transform.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable, FlatMapValue } from './types'
 import { flatten } from './flatten'
 import { filter } from './filter'

--- a/lib/flatten.ts
+++ b/lib/flatten.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 
 export async function* flatten<B>(iterable: AnyIterable<B | AnyIterable<B>>): AsyncIterableIterator<B> {

--- a/lib/from-stream.ts
+++ b/lib/from-stream.ts
@@ -1,5 +1,10 @@
-import { Readable } from 'stream'
-async function onceReadable(stream: Readable) {
+/// <reference lib="esnext.asynciterable" />
+interface IReadable {
+  once: any
+  read: any
+}
+
+async function onceReadable(stream: IReadable) {
   return new Promise(resolve => {
     stream.once('readable', () => {
       resolve()
@@ -7,7 +12,7 @@ async function onceReadable(stream: Readable) {
   })
 }
 
-async function* _fromStream(stream: Readable) {
+async function* _fromStream(stream: IReadable) {
   while (true) {
     const data = stream.read()
     if (data !== null) {
@@ -21,9 +26,9 @@ async function* _fromStream(stream: Readable) {
   }
 }
 
-export function fromStream<T>(stream: Readable): AsyncIterable<T> {
+export function fromStream<T>(stream: IReadable): AsyncIterable<T> {
   if (typeof stream[Symbol.asyncIterator] === 'function') {
-    return stream
+    return stream as any
   }
 
   return _fromStream(stream) as AsyncIterable<T>

--- a/lib/get-iterator.ts
+++ b/lib/get-iterator.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { Iterableish } from './types'
 
 export function getIterator<T>(iterable: Iterable<T> | Iterator<T>): Iterator<T>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
+/// <reference lib="esnext.asynciterable" />
+
 if ((Symbol as any).asyncIterator === undefined) {
   ;(Symbol as any).asyncIterator = Symbol.for('asyncIterator')
 }

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 async function* _map<T, B>(func: (data: T) => B | Promise<B>, iterable: AnyIterable<T>) {
   for await (const val of iterable) {

--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { getIterator } from './get-iterator'
 import { AnyIterable } from './types'
 

--- a/lib/parallel-flat-map.ts
+++ b/lib/parallel-flat-map.ts
@@ -1,4 +1,5 @@
-import { AnyIterable, FlatMapValue } from './types'
+/// <reference lib="esnext.asynciterable" />
+import { AnyIterable } from './types'
 import { flatten } from './flatten'
 import { filter } from './filter'
 import { parallelMap } from './parallel-map'

--- a/lib/parallel-map.ts
+++ b/lib/parallel-map.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 import { buffer } from './buffer'
 import { pipeline } from './pipeline'

--- a/lib/parallel-merge.ts
+++ b/lib/parallel-merge.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { getIterator } from './get-iterator'
 import { AnyIterable } from './types'
 

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -1,4 +1,3 @@
-// export function pipeline<T>(firstFn: () => T, ...fns: Array<(arg: T) => T>): T
 export function pipeline<T0>(firstFn: () => T0): T0
 export function pipeline<T0, T1>(a0: () => T0, a1: (a: T0) => T1): T1
 export function pipeline<T0, T1, T2>(a0: () => T0, a1: (a: T0) => T1, a2: (a: T1) => T2): T2

--- a/lib/reduce.ts
+++ b/lib/reduce.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 export async function _reduce<T, B>(func: (acc: B, value: T) => B, start: B, iterable: AnyIterable<T>) {
   let value = start

--- a/lib/take.ts
+++ b/lib/take.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 
 async function* _take<T>(count: number, iterable: AsyncIterable<T>) {

--- a/lib/tap.ts
+++ b/lib/tap.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 
 async function* _asyncTap<T>(func: (data: T) => any, iterable: AnyIterable<T>) {

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 
 interface ITimeConfig {

--- a/lib/transform.ts
+++ b/lib/transform.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 import { getIterator } from './get-iterator'
 import { defer, IDeferred } from './defer'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.asynciterable" />
 export type Iterableish<T> = Iterable<T> | Iterator<T> | AsyncIterable<T> | AsyncIterator<T>
 export type AnyIterable<T> = Iterable<T> | AsyncIterable<T>
 export type FlatMapValue<B> = B | AnyIterable<B> | undefined | null | Promise<B | AnyIterable<B> | undefined | null>

--- a/lib/write-to-stream.ts
+++ b/lib/write-to-stream.ts
@@ -1,13 +1,18 @@
-import { Writable } from 'stream'
+/// <reference lib="esnext.asynciterable" />
 import { AnyIterable } from './types'
 
-function waitForDrain(stream) {
+interface IWritable {
+  once: any
+  write: any
+}
+
+function waitForDrain(stream: IWritable) {
   return new Promise(resolve => {
     stream.once('drain', resolve)
   })
 }
 
-async function _writeToStream(stream: Writable, iterable: AnyIterable<any>) {
+async function _writeToStream(stream: IWritable, iterable: AnyIterable<any>) {
   for await (const value of iterable) {
     if (stream.write(value) === false) {
       await waitForDrain(stream)
@@ -15,9 +20,9 @@ async function _writeToStream(stream: Writable, iterable: AnyIterable<any>) {
   }
 }
 
-export function writeToStream(stream: Writable): (iterable: AnyIterable<any>) => Promise<void>
-export function writeToStream(stream: Writable, iterable: AnyIterable<any>): Promise<void>
-export function writeToStream(stream: Writable, iterable?: AnyIterable<any>) {
+export function writeToStream(stream: IWritable): (iterable: AnyIterable<any>) => Promise<void>
+export function writeToStream(stream: IWritable, iterable: AnyIterable<any>): Promise<void>
+export function writeToStream(stream: IWritable, iterable?: AnyIterable<any>) {
   if (iterable === undefined) {
     return (curriedIterable: AnyIterable<any>) => _writeToStream(stream, curriedIterable)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,114 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@microsoft/api-extractor": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-6.3.0.tgz",
+      "integrity": "sha512-rhC3Wc/Zaj44W8hJYJlaf+gFGxVwLvSEOnPslYUi3anFbtXBNZpK3ocF10SgtSaca2QfKA8UNN1rCIwXUCdz7g==",
+      "dev": true,
+      "requires": {
+        "@microsoft/node-core-library": "3.7.0",
+        "@microsoft/ts-command-line": "4.2.2",
+        "@microsoft/tsdoc": "0.12.2",
+        "@types/node": "8.5.8",
+        "@types/z-schema": "3.16.31",
+        "colors": "~1.2.1",
+        "jju": "~1.3.0",
+        "lodash": "~4.17.5",
+        "resolve": "1.8.1",
+        "typescript": "~3.1.6",
+        "z-schema": "~3.18.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+          "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+          "dev": true
+        }
+      }
+    },
+    "@microsoft/node-core-library": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.7.0.tgz",
+      "integrity": "sha512-Mae+MFnlcrcEmd6cmNzSv7xG74jWtQRlcOVjIwi10lECwm2LJIaiCol/PrsyARnjroDzf1eDH3quXSY7dTxLaA==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "5.0.4",
+        "@types/node": "8.5.8",
+        "@types/z-schema": "3.16.31",
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "jju": "~1.3.0",
+        "z-schema": "~3.18.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        }
+      }
+    },
+    "@microsoft/ts-command-line": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.2.2.tgz",
+      "integrity": "sha512-CLLVG+zWmUvD6jZD5oq7QCFYj3WOvrBSc3H6KejXCH6q2ntP5/ZHlmKVzQVvN1cEOSWP+jN9ml2AvUcDY/l6Tw==",
+      "dev": true,
+      "requires": {
+        "@types/argparse": "1.0.33",
+        "@types/node": "8.5.8",
+        "argparse": "~1.0.9",
+        "colors": "~1.2.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        }
+      }
+    },
+    "@microsoft/tsdoc": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.2.tgz",
+      "integrity": "sha512-L/srhENhBtbZLUD9FfJ2ZQdnYv3A3MT3UI2EMbC06fHUzIxLjjbkomD6o42UrbsRMwlS9p1BtxExeaCdX73q2Q==",
+      "dev": true
+    },
+    "@types/argparse": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.33.tgz",
+      "integrity": "sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
       "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
       "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/mocha": {
       "version": "5.2.5",
@@ -20,6 +123,18 @@
       "version": "10.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.4.tgz",
       "integrity": "sha512-0aFZiYCvoxyKP/Mg6PvqBb2UtWGIPf63r6rOAvRBrgyJOfanbL60yUH2U4FSpg+Yn6FW+JVYWtzn6hLTy745Fg==",
+      "dev": true
+    },
+    "@types/z-schema": {
+      "version": "3.16.31",
+      "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz",
+      "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
     "ansi-regex": {
@@ -164,6 +279,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true
+    },
     "commander": {
       "version": "2.15.1",
       "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
@@ -231,6 +352,17 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -256,6 +388,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -300,6 +438,12 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -310,6 +454,12 @@
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
       "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jju": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
       "dev": true
     },
     "js-tokens": {
@@ -328,6 +478,15 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -338,6 +497,18 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "make-error": {
@@ -488,6 +659,59 @@
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
+      }
+    },
+    "rollup": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+      "integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.9.5",
+        "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.10.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz",
+          "integrity": "sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz",
+      "integrity": "sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+          "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "safe-buffer": {
@@ -683,15 +907,27 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "validator": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
+      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
       "dev": true
     },
     "wrappy": {
@@ -711,6 +947,18 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
+    },
+    "z-schema": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
+      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^8.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "streaming-iterables",
   "version": "3.5.0",
   "description": "A collection of utilities for async iterables. Designed to replace your streams.",
-  "main": "dist",
+  "main": "dist/index.js",
+  "module": "dist/index-esm.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:reconbot/streaming-iterables.git",
   "homepage": "https://github.com/reconbot/streaming-iterables",
@@ -12,7 +13,7 @@
     "unit-test": "mocha --opts lib/mocha.opts",
     "lint": "tsc && tslint lib/*.ts",
     "format": "tslint lib/*.ts --fix",
-    "build": "tsc -p tsconfig-build.json",
+    "build": "tsc -p tsconfig-build.json && rollup -c rollup.config-esm.js && rollup -c rollup.config-umd.js && node bundle-types.js",
     "prepare": "npm run build"
   },
   "keywords": [
@@ -35,6 +36,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@microsoft/api-extractor": "^6.3.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.4",
@@ -43,12 +45,15 @@
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
     "prettier": "^1.15.2",
+    "rollup": "^1.4.1",
+    "rollup-plugin-node-resolve": "^4.0.1",
     "through2-concurrent": "^2.0.0",
     "ts-node": "^7.0.1",
+    "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.16.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.1.6"
+    "typescript": "^3.3.3333"
   },
   "engines": {
     "node": ">=8"

--- a/rollup.config-esm.js
+++ b/rollup.config-esm.js
@@ -1,0 +1,12 @@
+import resolve from 'rollup-plugin-node-resolve'
+
+export default {
+  input: './dist-ts/index.js',
+  plugins: [
+    resolve({})
+  ],
+  output: {
+    format: 'esm',
+    file: './dist/index-esm.js'
+  }
+}

--- a/rollup.config-umd.js
+++ b/rollup.config-umd.js
@@ -1,0 +1,13 @@
+import resolve from 'rollup-plugin-node-resolve'
+
+export default {
+  input: './dist-ts/index.js',
+  plugins: [
+    resolve({})
+  ],
+  output: {
+    format: 'umd',
+    name: 'streamingIterables',
+    file: './dist/index.js'
+  }
+}

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "noEmit": false
+    "outDir": "dist-ts",
+    "noEmit": false,
+    "module": "es6"
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,7 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "declaration": true,
-    "lib": [
-      "es2017",
-      "esnext.asynciterable"
-    ],
+    "importHelpers": true
   },
   "include": [
     "lib/*",


### PR DESCRIPTION
Advice from https://speakerdeck.com/southpolesteve/shipping-typescript-to-npm

- Using simple mocks for stream interfaces instead of exporting nodejs streams
- reference the lib esnext.asynciterable instead of importing it
- use rollup and tslib to package esm and umd builds
- bundle types too
- don’t know how to stop dist/tsdoc-metadata.json from being made but we can ignore it
