### PR TITLE
Throw the first seen stream error in writeToStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ for await (page of download(urls)) {
 function writeToStream(stream: Writable, iterable: AnyIterable<any>): Promise<void>
 ```
 
-Writes the `iterable` to the stream respecting the stream backpressure. Resolves when the iterable is exhausted.
+Writes the `iterable` to the stream respecting the stream backpressure. Resolves when the iterable is exhausted. Rejects and stops reading from the iterable when the stream emits an error.
 
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -497,8 +497,11 @@ for await (page of download(urls)) {
 function writeToStream(stream: Writable, iterable: AnyIterable<any>): Promise<void>
 ```
 
-Writes the `iterable` to the stream respecting the stream backpressure. Resolves when the iterable is exhausted. Rejects and stops reading from the iterable when the stream emits an error.
+Writes the `iterable` to the stream respecting the stream backpressure. Resolves when the iterable is exhausted, rejects if the stream errors during calls to `write()` or if there are `error` events during the write.
 
+As it is when working with streams there are a few caveats;
+- It is possible for the stream to error after `writeToStream()` has finished writing due to internal buffering and other concerns, so always handle errors on the stream as well.
+- `writeToStream()` doesn't close the stream like `stream.pipe()` might. This is done so you can write to the stream multiple times. You can call `stream.write(null)` or any stream specific end function if you are done with the stream.
 
 ```ts
 import { pipeline, map, writeToStream } from 'streaming-iterables'
@@ -508,7 +511,7 @@ import { createWriteStream } from 'fs'
 const file = createWriteStream('pokemon.ndjson')
 const serialize = map(pokemon => `${JSON.stringify(pokemon)}\n`)
 await pipeline(getPokemon, serialize, writeToStream(file))
-file.end()
+file.end() // close the stream
 // now all the pokemon are written to the file!
 ```
 

--- a/lib/write-to-stream-test.ts
+++ b/lib/write-to-stream-test.ts
@@ -63,54 +63,54 @@ describe('writeToStream', () => {
   it('throws the first stream error it sees', async () => {
     const values = [1, 2, 3, 4, 5]
     const stream = new Writable({ objectMode: true })
-    stream._write = function (value, _env, cb) {
-      if (value % 2 == 0) {
+    stream._write = (value, env, cb) => {
+      if (value % 2 === 0) {
         cb(new Error(`Even numbers are not allowed: ${value}`))
       } else {
         cb()
       }
     }
     try {
-      await writeToStream(stream, values);
+      await writeToStream(stream, values)
       assert.fail('writeToStream did not throw')
     } catch (err) {
       assert.equal(err.message, 'Even numbers are not allowed: 2')
     }
   })
   it('stops pulling values from the iterator after an error', async () => {
-    let iterations = 0;
+    let iterations = 0
     function* values() {
       for (let i = 1; i <= 5; i++) {
-        yield i;
-        iterations++;
+        yield i
+        iterations++
       }
     }
     const stream = new Writable({ objectMode: true })
-    stream._write = function (value, _env, cb) {
-      if (value % 2 == 0) {
+    stream._write = (value, env, cb) => {
+      if (value % 2 === 0) {
         cb(new Error(`Even numbers are not allowed: ${value}`))
       } else {
         cb()
       }
     }
     try {
-      await writeToStream(stream, values());
+      await writeToStream(stream, values())
       assert.fail('writeToStream did not throw')
     } catch (err) {
       assert.equal(err.message, 'Even numbers are not allowed: 2')
-      assert.equal(iterations, 2);
+      assert.equal(iterations, 2)
     }
   })
   it('leaves no dangling error handlers on success', async () => {
     const values = [1, 2, 3]
     const stream = new PassThrough({ highWaterMark: 4, objectMode: true })
     await writeToStream(stream, values)
-    assert.equal(stream.listenerCount('error'), 0);
+    assert.equal(stream.listenerCount('error'), 0)
   })
   it('leaves no dangling error handlers on error', async () => {
     const values = [1, 2, 3]
     const stream = new Writable({ objectMode: true })
-    stream._write = function (_value, _env, cb) {
+    stream._write = (value, env, cb) => {
       cb(new Error('nope'))
     }
     try {
@@ -118,7 +118,7 @@ describe('writeToStream', () => {
       assert.fail('writeToStream did not throw')
     } catch (err) {
       assert.equal(err.message, 'nope')
-      assert.equal(stream.listenerCount('error'), 0);
+      assert.equal(stream.listenerCount('error'), 0)
     }
   })
 })

--- a/lib/write-to-stream-test.ts
+++ b/lib/write-to-stream-test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { writeToStream } from './'
-import { PassThrough, Transform } from 'stream'
+import { PassThrough, Transform, Writable } from 'stream'
 import { promiseImmediate } from './util-test'
 
 describe('writeToStream', () => {
@@ -59,5 +59,66 @@ describe('writeToStream', () => {
     const stream = new PassThrough({ highWaterMark: 4, objectMode: true })
     stream.resume()
     await writeToStream(stream, values)
+  })
+  it('throws the first stream error it sees', async () => {
+    const values = [1, 2, 3, 4, 5]
+    const stream = new Writable({ objectMode: true })
+    stream._write = function (value, _env, cb) {
+      if (value % 2 == 0) {
+        cb(new Error(`Even numbers are not allowed: ${value}`))
+      } else {
+        cb()
+      }
+    }
+    try {
+      await writeToStream(stream, values);
+      assert.fail('writeToStream did not throw')
+    } catch (err) {
+      assert.equal(err.message, 'Even numbers are not allowed: 2')
+    }
+  })
+  it('stops pulling values from the iterator after an error', async () => {
+    let iterations = 0;
+    function* values() {
+      for (let i = 1; i <= 5; i++) {
+        yield i;
+        iterations++;
+      }
+    }
+    const stream = new Writable({ objectMode: true })
+    stream._write = function (value, _env, cb) {
+      if (value % 2 == 0) {
+        cb(new Error(`Even numbers are not allowed: ${value}`))
+      } else {
+        cb()
+      }
+    }
+    try {
+      await writeToStream(stream, values());
+      assert.fail('writeToStream did not throw')
+    } catch (err) {
+      assert.equal(err.message, 'Even numbers are not allowed: 2')
+      assert.equal(iterations, 2);
+    }
+  })
+  it('leaves no dangling error handlers on success', async () => {
+    const values = [1, 2, 3]
+    const stream = new PassThrough({ highWaterMark: 4, objectMode: true })
+    await writeToStream(stream, values)
+    assert.equal(stream.listenerCount('error'), 0);
+  })
+  it('leaves no dangling error handlers on error', async () => {
+    const values = [1, 2, 3]
+    const stream = new Writable({ objectMode: true })
+    stream._write = function (_value, _env, cb) {
+      cb(new Error('nope'))
+    }
+    try {
+      await writeToStream(stream, values)
+      assert.fail('writeToStream did not throw')
+    } catch (err) {
+      assert.equal(err.message, 'nope')
+      assert.equal(stream.listenerCount('error'), 0);
+    }
   })
 })

--- a/lib/write-to-stream.ts
+++ b/lib/write-to-stream.ts
@@ -2,14 +2,14 @@
 import { AnyIterable } from './types'
 
 interface IWritable {
-  removeListener: any
   once: any
   write: any
+  removeListener: any
 }
 
-function waitForDrain(stream: IWritable) {
+function once(event: string, stream: IWritable): Promise<any> {
   return new Promise(resolve => {
-    stream.once('drain', resolve)
+    stream.once(event, resolve)
   })
 }
 
@@ -23,7 +23,7 @@ async function _writeToStream(stream: IWritable, iterable: AnyIterable<any>) {
   for await (const value of iterable) {
     await Promise.race([errorPromise, Promise.resolve()])
     if (stream.write(value) === false) {
-      await Promise.race([errorPromise, waitForDrain(stream)])
+      await Promise.race([errorPromise, once('drain', stream)])
     }
   }
 

--- a/lib/write-to-stream.ts
+++ b/lib/write-to-stream.ts
@@ -2,7 +2,7 @@
 import { AnyIterable } from './types'
 
 interface IWritable {
-  off: any
+  removeListener: any
   once: any
   write: any
 }
@@ -30,7 +30,7 @@ async function _writeToStream(stream: IWritable, iterable: AnyIterable<any>) {
     }
   }
 
-  stream.off('error', errorHandler)
+  stream.removeListener('error', errorHandler)
 }
 
 export function writeToStream(stream: IWritable): (iterable: AnyIterable<any>) => Promise<void>

--- a/lib/write-to-stream.ts
+++ b/lib/write-to-stream.ts
@@ -2,6 +2,7 @@
 import { AnyIterable } from './types'
 
 interface IWritable {
+  off: any,
   once: any
   write: any
 }
@@ -13,11 +14,23 @@ function waitForDrain(stream: IWritable) {
 }
 
 async function _writeToStream(stream: IWritable, iterable: AnyIterable<any>) {
+  let error: Error | undefined;
+  function errorHandler(err: Error) {
+    error = err;
+  }
+  stream.once('error', errorHandler)
+
   for await (const value of iterable) {
+    if (error) {
+      throw error
+    }
+
     if (stream.write(value) === false) {
       await waitForDrain(stream)
     }
   }
+
+  stream.off('error', errorHandler)
 }
 
 export function writeToStream(stream: IWritable): (iterable: AnyIterable<any>) => Promise<void>

--- a/lib/write-to-stream.ts
+++ b/lib/write-to-stream.ts
@@ -2,7 +2,7 @@
 import { AnyIterable } from './types'
 
 interface IWritable {
-  off: any,
+  off: any
   once: any
   write: any
 }
@@ -14,9 +14,9 @@ function waitForDrain(stream: IWritable) {
 }
 
 async function _writeToStream(stream: IWritable, iterable: AnyIterable<any>) {
-  let error: Error | undefined;
+  let error: Error | undefined
   function errorHandler(err: Error) {
-    error = err;
+    error = err
   }
   stream.once('error', errorHandler)
 


### PR DESCRIPTION
Fixes #30 

This makes it so that if the stream we're writing to emit's an error, we interrupt reading the iterator and throw an error.

This makes a somewhat reasonable assumption about stream. It assumes that we're pretty much done with the stream once it emits it's first error. 

Technically speaking this is not 100% true when it comes to node since a writable stream can still work and process data even if it has already emitted an error. Also, node streams can emit as many errors as they want.

I think that this is still a reasonable approach. Fail-fast is generally speaking a good idea. On top of what node streams will crash the process on their first unhandled error which is similar behaviour.